### PR TITLE
Fix typo in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ $client = new SoapClient(
         'password' => '12345',
         'curlopts' => array(CURLOPT_SSL_VERIFYPEER => false),
     )
-};
+);
 ```
 
 #### Available options


### PR DESCRIPTION
Just a simple typo fix in documentation. It helps if you copy the code from the README, as it is incorrect right now.